### PR TITLE
Unpin Go Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.20
+FROM golang
 
-ENV KUBERNETES_VERSION="1.27"
+ENV KUBERNETES_VERSION="1.29"
 ENV ARGS="./..."
 
 COPY scripts/envtest.sh /envtest.sh


### PR DESCRIPTION
Pinning the version causes problems with the go test action in load-balancer-operator.